### PR TITLE
Dashboard

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,10 @@ class ApplicationController < ActionController::Base
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
 
+  def require_user
+    render file: 'public/404', status: 404 unless current_user
+  end
+
   def generate_flash(resource)
     error_messages = String.new
     resource.errors.messages.each do |validation, message|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :require_user, only: :show
+  
   def new
 
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,8 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(session[:user_id])
+    # @user = User.find(session[:user_id])
+    @user = current_user
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
   has_many :followees, through: :followed_users
   has_many :following_users, foreign_key: :followee_id, class_name: 'Friendship'
   has_many :followers, through: :following_users
+  has_many :parties
+  # have_many :party_participants, through: :parties
 
   has_secure_password
 
@@ -27,6 +29,4 @@ class User < ApplicationRecord
 
 
 
-  # have_many :parties
-  # have_many :party_participants, through: :parties
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,8 +3,13 @@
 <h1>Welcome <%= @user.email %>!</h1>
 <%= button_to "Discover Movies", "/discover" %>
 <section id="friends">
-
+  <h3>Friends</h3>
+  <!-- Add a line under header Friends -->
+  <!-- Form for friends email -->
+  <!-- Button for add friend -->
+  <!-- Friends list OR 'You currently have no friends.' -->
 </section>
 <section id="parties">
-
+  <h3>Viewing Parties</h3>
+  <!-- Card with image; movie title; date of party; time of party; statys(hosting or invited) -->
 </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,10 @@
 <!-- Wireframe shows an emoji or image in the top left corner -->
 <!-- The welcome is centered off the image -->
 <h1>Welcome <%= @user.email %>!</h1>
+<%= button_to "Discover Movies", "/discover" %>
+<section id="friends">
+
+</section>
+<section id="parties">
+
+</section>

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe "Dashboard Page", type: :feature do
+  describe "As a registered user" do
+    before :each do
+      @rainbow_dash = User.create!(email:"rainbow_dash@email.com", password:"User@us3r")
+      @pinkie_pie = User.create!(email:"pinkie_pie@email.com", password:"User@us3r")
+      @twilight_sparkle = User.create!(email:"twilight_sparkle@email.com", password:"User@us3r")
+      @rarity = User.create!(email:"rarity@email.com", password:"User@us3r")
+      @applejack = User.create!(email:"applejack@email.com", password:"User@us3r")
+      @fluttershy = User.create!(email:"fluttershy@email.com", password:"User@us3r")
+      @spike = User.create!(email:"spike@email.com", password:"User@us3r")
+      @starlight_glimmer = User.create!(email:"starlight_glimmer@email.com", password:"User@us3r")
+
+      @rainbow_dash.followers << [@rarity, @applejack, @twilight_sparkle]
+      @twilight_sparkle.followers << [@spike, @starlight_glimmer]
+      @pinkie_pie.followers << [@rainbow_dash, @twilight_sparkle, @rarity, @applejack, @fluttershy, @spike, @starlight_glimmer]
+
+      @party_1  = @twilight_sparkle.parties.create!(movie_id:"4", runtime:"12", date:"Oct 12, 1940", start:"12 pm")
+
+      THIS IS WHERE WE GET STUCK
+      - Do we need to update friendships? (if I friend you, shouldnt it automatically friend me back?)
+      - PartyParticipants and Friendships arent working
+      - This MAY have to be top down so that the features can drive the database
+      - We may have to go back to the idea of an array of participant ids (this seems easier to update in the long run)
+      binding.pry
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@twilight_sparkle)
+    end
+
+    it "can have a dashboard page" do
+      visit "/dashboard"
+      expect(page).to have_content("Welcome #{@twilight_sparkle.email}!")
+      expect(page).to have_button("Discover Movies")
+      within "#friends" do
+        # because she added as followers
+        expect(page).to have_content(@spike.email)
+        expect(page).to have_content(@starlight_glimmer.email)
+        # because rainbow_dash added her
+        expect(page).to_not have_content(@rainbow_dash.email)
+        # because there is NO connection
+        expect(page).to_not have_content(@fluttershy.email)
+      end
+      within "#parties" do
+        expect(page).to have_content()
+      end
+    end
+
+  end
+
+  # describe "As a non-registered user" do
+  #   it "can see 400 errors when trying to access the database" do
+  #     visit "/dashboard"
+  #     expect(page).to have_content("Oops")
+  #   end
+  #
+  #   it "can redirect you to welcome? (does this imply a custom 400 error page?)"
+  # end
+end

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe "Dashboard Page", type: :feature do
 
       @party_1  = @twilight_sparkle.parties.create!(movie_id:"4", runtime:"12", date:"Oct 12, 1940", start:"12 pm")
 
-      THIS IS WHERE WE GET STUCK
-      - Do we need to update friendships? (if I friend you, shouldnt it automatically friend me back?)
-      - PartyParticipants and Friendships arent working
-      - This MAY have to be top down so that the features can drive the database
-      - We may have to go back to the idea of an array of participant ids (this seems easier to update in the long run)
-      binding.pry
+      # THIS IS WHERE WE GET STUCK
+      # - Do we need to update friendships? (if I friend you, shouldnt it automatically friend me back?)
+      # - PartyParticipants and Friendships arent working
+      # - This MAY have to be top down so that the features can drive the database
+      # - We may have to go back to the idea of an array of participant ids (this seems easier to update in the long run)
+      # binding.pry
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@twilight_sparkle)
     end
@@ -33,19 +33,35 @@ RSpec.describe "Dashboard Page", type: :feature do
       expect(page).to have_content("Welcome #{@twilight_sparkle.email}!")
       expect(page).to have_button("Discover Movies")
       within "#friends" do
-        # because she added as followers
-        expect(page).to have_content(@spike.email)
-        expect(page).to have_content(@starlight_glimmer.email)
-        # because rainbow_dash added her
-        expect(page).to_not have_content(@rainbow_dash.email)
-        # because there is NO connection
-        expect(page).to_not have_content(@fluttershy.email)
+        # # because she added as followers
+        # expect(page).to have_content(@spike.email)
+        # expect(page).to have_content(@starlight_glimmer.email)
+        # # because rainbow_dash added her
+        # expect(page).to_not have_content(@rainbow_dash.email)
+        # # because there is NO connection
+        # expect(page).to_not have_content(@fluttershy.email)
       end
       within "#parties" do
-        expect(page).to have_content()
+        # expect(page).to have_content()
       end
     end
 
+    it "can route discover movies button to discover page"
+    it "can see friends section with pertinent info"
+      # - test field for friends email
+      # - button to "Add friend"
+      # - Friend must be in database
+      # - No added friends = "You currently have no friends"
+      # - Added friends = List of all friends
+    it "can see a parties section with pertinent info"
+      # - Invited
+      #   - Movie Title
+      #   - Date and Time
+      #   - Status of Invited
+      # - Created
+      #   - Movie Title
+      #   - Date and Time
+      #   - Status of Host
   end
 
   # describe "As a non-registered user" do

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Dashboard Page", type: :feature do
   describe "As a non-registered user" do
     it "can see 400 errors when trying to access the database" do
       visit "/dashboard"
-      expect(page).to have_content("Oops")
+      expect(page).to have_content("The page you were looking for doesn't exist.")
     end
 
     # it "can redirect you to welcome? (does this imply a custom 400 error page?)"

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -33,16 +33,10 @@ RSpec.describe "Dashboard Page", type: :feature do
       expect(page).to have_content("Welcome #{@twilight_sparkle.email}!")
       expect(page).to have_button("Discover Movies")
       within "#friends" do
-        # # because she added as followers
-        # expect(page).to have_content(@spike.email)
-        # expect(page).to have_content(@starlight_glimmer.email)
-        # # because rainbow_dash added her
-        # expect(page).to_not have_content(@rainbow_dash.email)
-        # # because there is NO connection
-        # expect(page).to_not have_content(@fluttershy.email)
+        expect(page).to have_content("Friends")
       end
       within "#parties" do
-        # expect(page).to have_content()
+        expect(page).to have_content("Viewing Parties")
       end
     end
 
@@ -53,15 +47,23 @@ RSpec.describe "Dashboard Page", type: :feature do
       # - Friend must be in database
       # - No added friends = "You currently have no friends"
       # - Added friends = List of all friends
+        # expect(page).to have_content("Friends")
+        # # because she added as followers
+        # expect(page).to have_content(@spike.email)
+        # expect(page).to have_content(@starlight_glimmer.email)
+        # # because rainbow_dash added her
+        # expect(page).to_not have_content(@rainbow_dash.email)
+        # # because there is NO connection
+        # expect(page).to_not have_content(@fluttershy.email)
     it "can see a parties section with pertinent info"
       # - Invited
       #   - Movie Title
       #   - Date and Time
-      #   - Status of Invited
+      #   - Status == Invited
       # - Created
       #   - Movie Title
       #   - Date and Time
-      #   - Status of Host
+      #   - Status == Host
   end
 
   # describe "As a non-registered user" do

--- a/spec/features/dashboard/dashboard_spec.rb
+++ b/spec/features/dashboard/dashboard_spec.rb
@@ -66,12 +66,12 @@ RSpec.describe "Dashboard Page", type: :feature do
       #   - Status == Host
   end
 
-  # describe "As a non-registered user" do
-  #   it "can see 400 errors when trying to access the database" do
-  #     visit "/dashboard"
-  #     expect(page).to have_content("Oops")
-  #   end
-  #
-  #   it "can redirect you to welcome? (does this imply a custom 400 error page?)"
-  # end
+  describe "As a non-registered user" do
+    it "can see 400 errors when trying to access the database" do
+      visit "/dashboard"
+      expect(page).to have_content("Oops")
+    end
+
+    # it "can redirect you to welcome? (does this imply a custom 400 error page?)"
+  end
 end


### PR DESCRIPTION
**Contributors:** Priya

Closes #13 

**Details:** 
- Creates a dashboard page for users
- Expects a header, a button for "discover movies", a friends section, and a viewing party section
- Adds pending tests and comments for future issues that belong to this spec
- Sad Path: if user is not logged in, renders a public 404

**Improvements:** 
- Can the Sad Path (404) for an unauthorized user be made custom? If so, can we include a link back to the Welcome Page for a user to login?
- Is this as simple as routing to another page with a link back to login with our own custom 404 message?
- Or because this comes from "render file: public/404", is there a different way to do that?

- SimpleCov (%): 71 / 86 LOC (82.56%)
- SimpleCov Model (%): 31 / 105 LOC (29.52%)
- SimpleCov Feature (%): 68 / 87 LOC (78.16%)
- RuboCop (Complaints/Violations): 14 files inspected, 33 offenses detected